### PR TITLE
add versions.tf for 0.13

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
@nthock 

#1 

I was mistaken in the `versions.tf` - it should be placed in the same repository as the module. Could you create a new branch for 0.13 to ensure that older terraform versions are still supported?